### PR TITLE
Add test for key only entry

### DIFF
--- a/src/test/resources/bibtex.bib
+++ b/src/test/resources/bibtex.bib
@@ -21,6 +21,10 @@
 	key = "Value",
 }
 
+% Key only
+@article {test,
+}
+
 % Error object
 @error {
 }


### PR DESCRIPTION
This addas a test case showing that a bibtex entry having a key only raises an exception. IMHO following entry is valid bibtex:

```
@article{test,
}
```

The entry just hasn't any fields.